### PR TITLE
Add Secret Santa onboarding flow and API services

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,38 +1,315 @@
+:root {
+  color-scheme: light;
+  font-family: 'Segoe UI', Roboto, sans-serif;
+}
+
 .App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: #f7f9fc;
+  color: #1f2933;
+}
+
+.App-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  background: linear-gradient(135deg, #d97706, #c026d3);
+  color: #ffffff;
+}
+
+.App-brand {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.App-nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.App-nav button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.App-nav button:hover,
+.App-nav button:focus {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.App-user {
+  font-size: 0.9rem;
+  padding-right: 0.5rem;
+}
+
+.App-main {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  overflow-y: auto;
+}
+
+.App-footer {
+  text-align: center;
+  padding: 1rem 0;
+  font-size: 0.85rem;
+  color: #617184;
+}
+
+.App-confirmation,
+.Home,
+.Auth,
+.EventWizard {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 20px 45px -30px rgba(15, 23, 42, 0.35);
+  width: min(900px, 100%);
+}
+
+.App-confirmation h1 {
+  margin-top: 0;
+}
+
+.App-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.App-summary dt {
+  font-weight: 600;
+}
+
+.App-summary ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.App-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+button {
+  font: inherit;
+  border-radius: 8px;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #f97316, #8b5cf6);
+  color: #ffffff;
+  box-shadow: 0 10px 25px -15px rgba(139, 92, 246, 0.8);
+}
+
+button.secondary {
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  color: #1f2933;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px -16px rgba(15, 23, 42, 0.35);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.25rem;
+}
+
+.field label {
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.field input,
+.field textarea,
+.field select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.75rem;
+  font: inherit;
+}
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+  border-color: #8b5cf6;
+  outline: 2px solid rgba(139, 92, 246, 0.3);
+}
+
+.error {
+  color: #b91c1c;
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+}
+
+.Home-hero {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.Home-hero h1 {
+  margin-top: 0;
+  font-size: 2rem;
+}
+
+.Home-hero p {
+  font-size: 1rem;
+  color: #475569;
+}
+
+.Home-tutorial ol {
+  padding-left: 1rem;
+  counter-reset: tutorial;
+}
+
+.Home-tutorial li {
+  margin-bottom: 1rem;
+}
+
+.Home-tutorial h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.Auth header h1 {
+  margin: 0 0 0.5rem 0;
+}
+
+.Auth header p {
+  color: #475569;
+  margin-top: 0;
+}
+
+.Auth-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.EventWizard header h1 {
+  margin-top: 0;
+}
+
+.EventWizard-steps {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+  margin: 2rem 0 1.5rem;
+  flex-wrap: wrap;
+}
+
+.EventWizard-steps li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #334155;
+  font-weight: 600;
+}
+
+.EventWizard-steps li span {
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  background: #cbd5f5;
+  border-radius: 50%;
 }
 
-.App-link {
-  color: #61dafb;
+.EventWizard-steps li.active {
+  background: linear-gradient(135deg, #f97316, #8b5cf6);
+  color: #ffffff;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+.EventWizard-steps li.active span {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.ParticipantsStep-form {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: end;
+  margin-bottom: 1.5rem;
+}
+
+.ParticipantsStep-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ParticipantsStep-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  margin-bottom: 0.75rem;
+  background: #f8fafc;
+}
+
+.ConfirmationStep .summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.ConfirmationStep ul {
+  padding-left: 1.25rem;
+}
+
+@media (max-width: 640px) {
+  .App-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .App-nav {
+    flex-wrap: wrap;
+  }
+
+  .App-main {
+    padding: 1rem;
   }
 }

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,23 +1,158 @@
-import logo from './logo.svg';
+import { useMemo, useState } from 'react';
 import './App.css';
+import Home from './pages/Home';
+import Auth from './pages/Auth';
+import EventWizard from './pages/EventWizard/EventWizard';
 
 function App() {
+  const [view, setView] = useState('home');
+  const [creator, setCreator] = useState(null);
+  const [eventSummary, setEventSummary] = useState(null);
+
+  const navigation = useMemo(
+    () => ({
+      goHome: () => {
+        setView('home');
+        setEventSummary(null);
+      },
+      goAuth: () => setView('auth'),
+      goWizard: () => setView('wizard'),
+      goConfirmation: () => setView('confirmation'),
+    }),
+    []
+  );
+
+  const handleAuthSuccess = (account) => {
+    setCreator(account);
+    navigation.goWizard();
+  };
+
+  const handleEventComplete = (summary) => {
+    setEventSummary(summary);
+    navigation.goConfirmation();
+  };
+
+  const handleSignOut = () => {
+    setCreator(null);
+    setEventSummary(null);
+    navigation.goHome();
+  };
+
+  let content;
+
+  switch (view) {
+    case 'auth':
+      content = (
+        <Auth
+          onSuccess={handleAuthSuccess}
+          onCancel={navigation.goHome}
+        />
+      );
+      break;
+    case 'wizard':
+      content = (
+        <EventWizard
+          creator={creator}
+          onCancel={navigation.goHome}
+          onComplete={handleEventComplete}
+        />
+      );
+      break;
+    case 'confirmation':
+      content = (
+        <section className="App-confirmation" aria-live="polite">
+          <h1>Évènement créé avec succès !</h1>
+          <p>
+            Votre Secret Santa est prêt. Nous avons bien enregistré la date
+            limite, le budget ainsi que la liste des participants.
+          </p>
+          {eventSummary && (
+            <dl className="App-summary">
+              <div>
+                <dt>Créateur</dt>
+                <dd>{eventSummary.creatorEmail || creator?.email}</dd>
+              </div>
+              <div>
+                <dt>Titre</dt>
+                <dd>{eventSummary.title}</dd>
+              </div>
+              <div>
+                <dt>Date limite</dt>
+                <dd>{eventSummary.deadline}</dd>
+              </div>
+              <div>
+                <dt>Budget maximum</dt>
+                <dd>{eventSummary.budget} €</dd>
+              </div>
+              <div>
+                <dt>Lieu</dt>
+                <dd>{eventSummary.location}</dd>
+              </div>
+              <div>
+                <dt>Participants</dt>
+                <dd>
+                  <ul>
+                    {eventSummary.participants?.map((participant) => (
+                      <li key={participant.email}>{`${participant.name} - ${participant.email}`}</li>
+                    ))}
+                  </ul>
+                </dd>
+              </div>
+            </dl>
+          )}
+          <div className="App-actions">
+            <button type="button" onClick={navigation.goWizard}>
+              Créer un nouvel évènement
+            </button>
+            <button type="button" onClick={navigation.goHome}>
+              Retourner à l’accueil
+            </button>
+          </div>
+        </section>
+      );
+      break;
+    case 'home':
+    default:
+      content = (
+        <Home
+          onGetStarted={() => {
+            if (creator) {
+              navigation.goWizard();
+            } else {
+              navigation.goAuth();
+            }
+          }}
+        />
+      );
+      break;
+  }
+
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+        <div className="App-brand">Secret Santa Family Link</div>
+        <nav className="App-nav" aria-label="Navigation principale">
+          <button type="button" onClick={navigation.goHome}>
+            Accueil
+          </button>
+          {creator ? (
+            <>
+              <span className="App-user">{creator.email}</span>
+              <button type="button" onClick={handleSignOut}>
+                Déconnexion
+              </button>
+            </>
+          ) : (
+            <button type="button" onClick={navigation.goAuth}>
+              Connexion
+            </button>
+          )}
+        </nav>
       </header>
+      <main className="App-main">{content}</main>
+      <footer className="App-footer">
+        © {new Date().getFullYear()} Secret Santa Family Link
+      </footer>
     </div>
   );
 }

--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -1,8 +1,25 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
-test('renders learn react link', () => {
+test('affiche la page d’accueil avec le tutoriel', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', {
+      name: /Bienvenue sur le Secret Santa Family Link/i,
+    })
+  ).toBeInTheDocument();
+  expect(screen.getByText(/tutoriel détaillé/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /démarrer/i })).toBeInTheDocument();
+});
+
+test('redirige vers le formulaire de connexion lorsque l’on démarre', async () => {
+  render(<App />);
+  await userEvent.click(screen.getByRole('button', { name: /démarrer/i }));
+  expect(
+    screen.getByRole('heading', {
+      name: /connexion/i,
+    })
+  ).toBeInTheDocument();
+  expect(screen.getByLabelText(/adresse e-mail/i)).toBeInTheDocument();
 });

--- a/web/src/pages/Auth.js
+++ b/web/src/pages/Auth.js
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { loginCreator, registerCreator } from '../services/api';
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function Auth({ onSuccess, onCancel = () => {} }) {
+  const [mode, setMode] = useState('login');
+  const [form, setForm] = useState({
+    fullName: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  });
+  const [errors, setErrors] = useState({});
+  const [serverError, setServerError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const validate = () => {
+    const nextErrors = {};
+
+    if (!form.email) {
+      nextErrors.email = 'Adresse e-mail obligatoire.';
+    } else if (!emailRegex.test(form.email)) {
+      nextErrors.email = 'Adresse e-mail invalide.';
+    }
+
+    if (!form.password || form.password.length < 8) {
+      nextErrors.password =
+        'Le mot de passe doit contenir au moins 8 caractères.';
+    }
+
+    if (mode === 'register') {
+      if (!form.fullName.trim()) {
+        nextErrors.fullName = 'Merci d’indiquer votre nom complet.';
+      }
+      if (!form.confirmPassword) {
+        nextErrors.confirmPassword = 'Confirmez votre mot de passe.';
+      } else if (form.password !== form.confirmPassword) {
+        nextErrors.confirmPassword = 'Les mots de passe ne correspondent pas.';
+      }
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!validate()) {
+      return;
+    }
+
+    setLoading(true);
+    setServerError('');
+
+    try {
+      const payload = {
+        email: form.email,
+        password: form.password,
+      };
+
+      if (mode === 'register') {
+        const response = await registerCreator({
+          ...payload,
+          fullName: form.fullName.trim(),
+        });
+        if (onSuccess) {
+          onSuccess(response);
+        }
+      } else {
+        const response = await loginCreator(payload);
+        if (onSuccess) {
+          onSuccess(response);
+        }
+      }
+    } catch (error) {
+      setServerError(
+        error?.message || 'Impossible de contacter le serveur pour le moment.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const switchMode = () => {
+    setMode((prev) => (prev === 'login' ? 'register' : 'login'));
+    setErrors({});
+    setServerError('');
+  };
+
+  return (
+    <section className="Auth">
+      <header>
+        <h1>{mode === 'login' ? 'Connexion' : 'Inscription'}</h1>
+        <p>
+          {mode === 'login'
+            ? 'Connectez-vous pour configurer votre échange de cadeaux.'
+            : 'Créez votre compte de créateur pour lancer un nouvel évènement.'}
+        </p>
+      </header>
+      <form onSubmit={handleSubmit} noValidate>
+        {mode === 'register' && (
+          <div className="field">
+            <label htmlFor="fullName">Nom complet</label>
+            <input
+              id="fullName"
+              name="fullName"
+              type="text"
+              value={form.fullName}
+              onChange={handleChange}
+              autoComplete="name"
+            />
+            {errors.fullName && <span className="error">{errors.fullName}</span>}
+          </div>
+        )}
+        <div className="field">
+          <label htmlFor="email">Adresse e-mail</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            value={form.email}
+            onChange={handleChange}
+            autoComplete="email"
+            required
+          />
+          {errors.email && <span className="error">{errors.email}</span>}
+        </div>
+        <div className="field">
+          <label htmlFor="password">Mot de passe</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            value={form.password}
+            onChange={handleChange}
+            autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+            required
+          />
+          {errors.password && <span className="error">{errors.password}</span>}
+        </div>
+        {mode === 'register' && (
+          <div className="field">
+            <label htmlFor="confirmPassword">Confirmation du mot de passe</label>
+            <input
+              id="confirmPassword"
+              name="confirmPassword"
+              type="password"
+              value={form.confirmPassword}
+              onChange={handleChange}
+              autoComplete="new-password"
+              required
+            />
+            {errors.confirmPassword && (
+              <span className="error">{errors.confirmPassword}</span>
+            )}
+          </div>
+        )}
+        {serverError && <div className="error" role="alert">{serverError}</div>}
+        <div className="Auth-actions">
+          <button type="submit" disabled={loading} className="primary">
+            {loading ? 'Patientez…' : mode === 'login' ? 'Se connecter' : "S'inscrire"}
+          </button>
+          <button type="button" onClick={switchMode} disabled={loading}>
+            {mode === 'login'
+              ? "Pas encore de compte ? Inscrivez-vous"
+              : 'Déjà inscrit ? Connectez-vous'}
+          </button>
+          <button type="button" onClick={onCancel} disabled={loading}>
+            Annuler
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+export default Auth;

--- a/web/src/pages/EventWizard/ConfirmationStep.js
+++ b/web/src/pages/EventWizard/ConfirmationStep.js
@@ -1,0 +1,61 @@
+function ConfirmationStep({
+  details,
+  participants,
+  onBack = () => {},
+  onConfirm = () => {},
+  loading,
+  error,
+}) {
+  return (
+    <div className="ConfirmationStep">
+      <h2>Vérifiez les informations</h2>
+      <p>
+        Assurez-vous que tout est correct avant d’envoyer les invitations aux
+        participants. Vous pourrez ensuite suivre l’état des notifications.
+      </p>
+      <dl className="summary">
+        <div>
+          <dt>Titre</dt>
+          <dd>{details.title}</dd>
+        </div>
+        <div>
+          <dt>Date limite</dt>
+          <dd>{details.deadline}</dd>
+        </div>
+        <div>
+          <dt>Budget maximum</dt>
+          <dd>{details.budget} €</dd>
+        </div>
+        <div>
+          <dt>Lieu</dt>
+          <dd>{details.location}</dd>
+        </div>
+      </dl>
+      <section>
+        <h3>Participants ({participants.length})</h3>
+        <ul>
+          {participants.map((participant) => (
+            <li key={participant.email}>
+              {participant.name} — {participant.email}
+            </li>
+          ))}
+        </ul>
+      </section>
+      {error && (
+        <div className="error" role="alert">
+          {error}
+        </div>
+      )}
+      <div className="form-actions">
+        <button type="button" onClick={onBack} disabled={loading}>
+          Retour
+        </button>
+        <button type="button" onClick={onConfirm} className="primary" disabled={loading}>
+          {loading ? 'Création en cours…' : 'Confirmer et envoyer les invitations'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmationStep;

--- a/web/src/pages/EventWizard/EventDetailsStep.js
+++ b/web/src/pages/EventWizard/EventDetailsStep.js
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+
+function EventDetailsStep({ initialValues, onSubmit, onCancel = () => {} }) {
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState({});
+
+  const validate = () => {
+    const nextErrors = {};
+
+    if (!values.title.trim()) {
+      nextErrors.title = 'Indiquez un nom reconnaissable pour votre évènement.';
+    }
+
+    if (!values.deadline) {
+      nextErrors.deadline = 'La date limite est obligatoire.';
+    } else {
+      const deadlineDate = new Date(values.deadline);
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      if (Number.isNaN(deadlineDate.getTime())) {
+        nextErrors.deadline = 'La date limite doit être valide.';
+      } else if (deadlineDate < now) {
+        nextErrors.deadline = 'La date doit être dans le futur.';
+      }
+    }
+
+    if (!values.budget) {
+      nextErrors.budget = 'Le budget maximum est obligatoire.';
+    } else if (Number.isNaN(Number(values.budget)) || Number(values.budget) <= 0) {
+      nextErrors.budget = 'Le budget doit être un montant positif.';
+    }
+
+    if (!values.location.trim()) {
+      nextErrors.location = 'Merci de préciser le lieu de remise des cadeaux.';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (validate()) {
+      onSubmit(values);
+    }
+  };
+
+  return (
+    <form className="EventDetailsStep" onSubmit={handleSubmit} noValidate>
+      <div className="field">
+        <label htmlFor="title">Nom de l’évènement</label>
+        <input
+          id="title"
+          name="title"
+          type="text"
+          value={values.title}
+          onChange={handleChange}
+          placeholder="Secret Santa de la famille Dupont"
+        />
+        {errors.title && <span className="error">{errors.title}</span>}
+      </div>
+      <div className="field">
+        <label htmlFor="deadline">Date limite d’envoi</label>
+        <input
+          id="deadline"
+          name="deadline"
+          type="date"
+          value={values.deadline}
+          onChange={handleChange}
+          required
+        />
+        {errors.deadline && <span className="error">{errors.deadline}</span>}
+      </div>
+      <div className="field">
+        <label htmlFor="budget">Budget maximum (en €)</label>
+        <input
+          id="budget"
+          name="budget"
+          type="number"
+          min="1"
+          step="1"
+          value={values.budget}
+          onChange={handleChange}
+          required
+        />
+        {errors.budget && <span className="error">{errors.budget}</span>}
+      </div>
+      <div className="field">
+        <label htmlFor="location">Lieu de l’échange</label>
+        <input
+          id="location"
+          name="location"
+          type="text"
+          value={values.location}
+          onChange={handleChange}
+          placeholder="Chez Mamie, 24 décembre"
+        />
+        {errors.location && <span className="error">{errors.location}</span>}
+      </div>
+      <div className="form-actions">
+        <button type="button" onClick={onCancel}>
+          Annuler
+        </button>
+        <button type="submit" className="primary">
+          Continuer
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default EventDetailsStep;

--- a/web/src/pages/EventWizard/EventWizard.js
+++ b/web/src/pages/EventWizard/EventWizard.js
@@ -1,0 +1,129 @@
+import { useMemo, useState } from 'react';
+import { createEvent } from '../../services/api';
+import EventDetailsStep from './EventDetailsStep';
+import ParticipantsStep from './ParticipantsStep';
+import ConfirmationStep from './ConfirmationStep';
+
+const initialDetails = {
+  title: '',
+  deadline: '',
+  budget: '',
+  location: '',
+};
+
+function EventWizard({ creator, onCancel = () => {}, onComplete }) {
+  const steps = useMemo(
+    () => [
+      { id: 'details', label: 'Paramètres' },
+      { id: 'participants', label: 'Participants' },
+      { id: 'confirmation', label: 'Confirmation' },
+    ],
+    []
+  );
+  const [currentStep, setCurrentStep] = useState(0);
+  const [details, setDetails] = useState(initialDetails);
+  const [participants, setParticipants] = useState([]);
+  const [submission, setSubmission] = useState({
+    loading: false,
+    error: '',
+  });
+
+  const goBack = () => {
+    setCurrentStep((prev) => Math.max(prev - 1, 0));
+  };
+
+  const goNext = () => {
+    setCurrentStep((prev) => Math.min(prev + 1, steps.length - 1));
+  };
+
+  const handleConfirm = async () => {
+    setSubmission({ loading: true, error: '' });
+    try {
+      const payload = {
+        ...details,
+        budget: Number(details.budget),
+        participants,
+        creatorId: creator?.id || null,
+        creatorEmail: creator?.email || null,
+      };
+      const response = await createEvent(payload);
+      setSubmission({ loading: false, error: '' });
+      if (onComplete) {
+        onComplete({ ...payload, ...response });
+      }
+    } catch (error) {
+      setSubmission({
+        loading: false,
+        error: error?.message || "Une erreur inattendue est survenue.",
+      });
+    }
+  };
+
+  let stepContent;
+
+  switch (steps[currentStep].id) {
+    case 'details':
+      stepContent = (
+        <EventDetailsStep
+          initialValues={details}
+          onSubmit={(values) => {
+            setDetails(values);
+            goNext();
+          }}
+          onCancel={onCancel}
+        />
+      );
+      break;
+    case 'participants':
+      stepContent = (
+        <ParticipantsStep
+          participants={participants}
+          onUpdate={setParticipants}
+          onNext={goNext}
+          onBack={goBack}
+          onCancel={onCancel}
+        />
+      );
+      break;
+    case 'confirmation':
+    default:
+      stepContent = (
+        <ConfirmationStep
+          details={details}
+          participants={participants}
+          onBack={goBack}
+          onConfirm={handleConfirm}
+          loading={submission.loading}
+          error={submission.error}
+        />
+      );
+      break;
+  }
+
+  return (
+    <section className="EventWizard">
+      <header>
+        <h1>Assistant de création d’évènement</h1>
+        <p>
+          Configurez votre Secret Santa étape par étape. Les informations
+          saisies sont sauvegardées à chaque progression.
+        </p>
+      </header>
+      <ol className="EventWizard-steps">
+        {steps.map((step, index) => (
+          <li
+            key={step.id}
+            aria-current={index === currentStep ? 'step' : undefined}
+            className={index === currentStep ? 'active' : ''}
+          >
+            <span>{index + 1}</span>
+            {step.label}
+          </li>
+        ))}
+      </ol>
+      <div className="EventWizard-content">{stepContent}</div>
+    </section>
+  );
+}
+
+export default EventWizard;

--- a/web/src/pages/EventWizard/ParticipantsStep.js
+++ b/web/src/pages/EventWizard/ParticipantsStep.js
@@ -1,0 +1,146 @@
+import { useMemo, useState } from 'react';
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function ParticipantsStep({
+  participants,
+  onUpdate,
+  onNext = () => {},
+  onBack = () => {},
+  onCancel = () => {},
+}) {
+  const [candidate, setCandidate] = useState({ name: '', email: '' });
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [globalError, setGlobalError] = useState('');
+
+  const sortedParticipants = useMemo(
+    () =>
+      [...participants].sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      ),
+    [participants]
+  );
+
+  const resetCandidate = () => {
+    setCandidate({ name: '', email: '' });
+    setFieldErrors({});
+  };
+
+  const handleCandidateChange = (event) => {
+    const { name, value } = event.target;
+    setCandidate((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleAddParticipant = (event) => {
+    event.preventDefault();
+    const nextErrors = {};
+    const trimmedName = candidate.name.trim();
+    const normalizedEmail = candidate.email.trim().toLowerCase();
+
+    if (!trimmedName) {
+      nextErrors.name = 'Le prénom ou surnom est requis.';
+    }
+    if (!normalizedEmail) {
+      nextErrors.email = "L'adresse e-mail est requise.";
+    } else if (!emailRegex.test(normalizedEmail)) {
+      nextErrors.email = 'Adresse e-mail invalide.';
+    } else if (participants.some((item) => item.email === normalizedEmail)) {
+      nextErrors.email = 'Ce participant est déjà présent.';
+    }
+
+    setFieldErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    onUpdate([
+      ...participants,
+      { name: trimmedName, email: normalizedEmail },
+    ]);
+    setGlobalError('');
+    resetCandidate();
+  };
+
+  const handleRemoveParticipant = (email) => {
+    onUpdate(participants.filter((participant) => participant.email !== email));
+  };
+
+  const handleNext = () => {
+    if (participants.length < 2) {
+      setGlobalError('Ajoutez au moins deux participants pour lancer un tirage.');
+      return;
+    }
+    setGlobalError('');
+    onNext();
+  };
+
+  return (
+    <div className="ParticipantsStep">
+      <p>Ajoutez chaque membre de la famille pour lui attribuer un destinataire.</p>
+      <form className="ParticipantsStep-form" onSubmit={handleAddParticipant}>
+        <div className="field">
+          <label htmlFor="participant-name">Nom</label>
+          <input
+            id="participant-name"
+            name="name"
+            type="text"
+            value={candidate.name}
+            onChange={handleCandidateChange}
+            placeholder="Ex. Alice"
+          />
+          {fieldErrors.name && <span className="error">{fieldErrors.name}</span>}
+        </div>
+        <div className="field">
+          <label htmlFor="participant-email">Adresse e-mail</label>
+          <input
+            id="participant-email"
+            name="email"
+            type="email"
+            value={candidate.email}
+            onChange={handleCandidateChange}
+            placeholder="alice@example.com"
+          />
+          {fieldErrors.email && <span className="error">{fieldErrors.email}</span>}
+        </div>
+        <button type="submit" className="secondary">
+          Ajouter
+        </button>
+      </form>
+      <div className="ParticipantsStep-list" role="group" aria-label="Participants">
+        {sortedParticipants.length === 0 ? (
+          <p>Vous n’avez pas encore ajouté de participant.</p>
+        ) : (
+          <ul>
+            {sortedParticipants.map((participant) => (
+              <li key={participant.email}>
+                <span>
+                  {participant.name} — {participant.email}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveParticipant(participant.email)}
+                >
+                  Retirer
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      {globalError && <div className="error" role="alert">{globalError}</div>}
+      <div className="form-actions">
+        <button type="button" onClick={onBack}>
+          Retour
+        </button>
+        <button type="button" onClick={handleNext} className="primary">
+          Continuer
+        </button>
+        <button type="button" onClick={onCancel}>
+          Annuler
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ParticipantsStep;

--- a/web/src/pages/Home.js
+++ b/web/src/pages/Home.js
@@ -1,0 +1,52 @@
+const steps = [
+  {
+    title: 'Préparez votre liste',
+    description:
+      'Rassemblez les adresses e-mail de chaque membre de la famille qui participera au tirage.',
+  },
+  {
+    title: 'Définissez les règles',
+    description:
+      'Choisissez une date limite pour l’échange, fixez un budget maximum et indiquez le lieu de la remise des cadeaux.',
+  },
+  {
+    title: 'Invitez et suivez',
+    description:
+      'Ajoutez vos participants, envoyez les invitations et suivez les confirmations directement depuis le tableau de bord.',
+  },
+];
+
+function Home({ onGetStarted = () => {} }) {
+  return (
+    <section className="Home">
+      <header className="Home-hero">
+        <h1>Bienvenue sur le Secret Santa Family Link</h1>
+        <p>
+          Organisez un échange de cadeaux mémorable en quelques minutes grâce à
+          notre assistant guidé pas à pas.
+        </p>
+        <button type="button" onClick={onGetStarted} className="primary">
+          Démarrer
+        </button>
+      </header>
+      <article className="Home-tutorial">
+        <h2>Tutoriel détaillé</h2>
+        <ol>
+          {steps.map((step) => (
+            <li key={step.title}>
+              <h3>{step.title}</h3>
+              <p>{step.description}</p>
+            </li>
+          ))}
+        </ol>
+        <p>
+          Une fois vos paramètres sauvegardés, Secret Santa Family Link se
+          charge de notifier chaque participant de son destinataire secret et
+          vous informe en cas de message ou de retard.
+        </p>
+      </article>
+    </section>
+  );
+}
+
+export default Home;

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -1,0 +1,72 @@
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:4000/api';
+
+async function request(path, options = {}) {
+  const url = `${API_BASE_URL}${path}`;
+  const config = {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    ...options,
+  };
+
+  if (config.body && typeof config.body === 'object' && !(config.body instanceof FormData)) {
+    config.body = JSON.stringify(config.body);
+  }
+
+  const response = await fetch(url, config);
+  const contentType = response.headers.get('content-type') || '';
+  const isJson = contentType.includes('application/json');
+  const data = isJson ? await response.json().catch(() => null) : await response.text();
+
+  if (!response.ok) {
+    const message =
+      (data && typeof data === 'object' && data.message) ||
+      (typeof data === 'string' && data) ||
+      'Une erreur est survenue lors de la communication avec le serveur.';
+    throw new Error(message);
+  }
+
+  return data;
+}
+
+export async function registerCreator({ fullName, email, password }) {
+  return request('/creators/register', {
+    method: 'POST',
+    body: { fullName, email, password },
+  });
+}
+
+export async function loginCreator({ email, password }) {
+  return request('/creators/login', {
+    method: 'POST',
+    body: { email, password },
+  });
+}
+
+export async function createEvent(eventData) {
+  return request('/events', {
+    method: 'POST',
+    body: eventData,
+  });
+}
+
+export async function fetchNotifications(eventId) {
+  return request(`/events/${eventId}/notifications`, {
+    method: 'GET',
+  });
+}
+
+export async function acknowledgeNotification(eventId, notificationId) {
+  return request(`/events/${eventId}/notifications/${notificationId}`, {
+    method: 'PATCH',
+    body: { status: 'read' },
+  });
+}
+
+export async function resendNotification(eventId, participantEmail) {
+  return request(`/events/${eventId}/notifications/resend`, {
+    method: 'POST',
+    body: { participantEmail },
+  });
+}


### PR DESCRIPTION
## Summary
- replace the default CRA shell with a navigation flow covering home, authentication, wizard and confirmation screens
- add dedicated Home, Auth and multi-step Event Wizard pages with validation and state management for event creation
- implement frontend API service helpers for creator auth, event creation and notification tracking endpoints

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ca91b987b4832086b6121869e2468c