### PR TITLE
Handle auth token storage and API headers

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -2,8 +2,16 @@ import { useEffect, useMemo, useState } from 'react';
 import Home from './pages/Home';
 import Auth from './pages/Auth';
 import EventWizard from './pages/EventWizard/EventWizard';
+import { AUTH_TOKEN_STORAGE_KEY, setAuthToken as setApiAuthToken } from './services/api';
 
 const THEME_STORAGE_KEY = 'ssfl-theme-preference';
+
+const getInitialAuthToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+};
 
 const getInitialThemePreference = () => {
   if (typeof window === 'undefined') {
@@ -28,6 +36,7 @@ function App() {
   const [eventSummary, setEventSummary] = useState(null);
   const [themePreference, setThemePreference] = useState(getInitialThemePreference);
   const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark);
+  const [authToken, setAuthToken] = useState(getInitialAuthToken);
 
   const navigation = useMemo(
     () => ({
@@ -42,8 +51,9 @@ function App() {
     []
   );
 
-  const handleAuthSuccess = (account) => {
-    setCreator(account);
+  const handleAuthSuccess = (token, account) => {
+    setAuthToken(token || null);
+    setCreator(account || null);
     navigation.goWizard();
   };
 
@@ -53,8 +63,10 @@ function App() {
   };
 
   const handleSignOut = () => {
+    setApiAuthToken(null);
     setCreator(null);
     setEventSummary(null);
+    setAuthToken(null);
     navigation.goHome();
   };
 
@@ -93,6 +105,18 @@ function App() {
       document.documentElement.setAttribute('data-theme', resolvedTheme);
     }
   }, [resolvedTheme]);
+
+  useEffect(() => {
+    setApiAuthToken(authToken);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (authToken) {
+      localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, authToken);
+    } else {
+      localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+    }
+  }, [authToken]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -139,6 +163,7 @@ function App() {
       content = (
         <EventWizard
           creator={creator}
+          authToken={authToken}
           onCancel={navigation.goHome}
           onComplete={handleEventComplete}
         />

--- a/web/src/pages/Auth.js
+++ b/web/src/pages/Auth.js
@@ -64,19 +64,17 @@ function Auth({ onSuccess, onCancel = () => {} }) {
         password: form.password,
       };
 
-      if (mode === 'register') {
-        const response = await registerCreator({
-          ...payload,
-          fullName: form.fullName.trim(),
-        });
-        if (onSuccess) {
-          onSuccess(response);
-        }
-      } else {
-        const response = await loginCreator(payload);
-        if (onSuccess) {
-          onSuccess(response);
-        }
+      const response =
+        mode === 'register'
+          ? await registerCreator({
+              ...payload,
+              fullName: form.fullName.trim(),
+            })
+          : await loginCreator(payload);
+
+      if (onSuccess) {
+        const { token, user } = response || {};
+        onSuccess(token, user);
       }
     } catch (error) {
       setServerError(

--- a/web/src/pages/EventWizard/EventWizard.js
+++ b/web/src/pages/EventWizard/EventWizard.js
@@ -11,7 +11,7 @@ const initialDetails = {
   location: '',
 };
 
-function EventWizard({ creator, onCancel = () => {}, onComplete }) {
+function EventWizard({ creator, authToken, onCancel = () => {}, onComplete }) {
   const steps = useMemo(
     () => [
       { id: 'details', label: 'Paramètres' },
@@ -56,7 +56,7 @@ function EventWizard({ creator, onCancel = () => {}, onComplete }) {
         creatorId: creator?.id || null,
         creatorEmail: creator?.email || null,
       };
-      const response = await createEvent(requestPayload);
+      const response = await createEvent(requestPayload, authToken);
       const eventData = response?.event || {};
       const summaryParticipants = Array.isArray(eventData.participants)
         ? eventData.participants

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -1,16 +1,42 @@
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000/api';
 
+export const AUTH_TOKEN_STORAGE_KEY = 'ssfl-auth-token';
+
+let storedAuthToken = null;
+
+export function setAuthToken(token) {
+  storedAuthToken = token || null;
+}
+
+export function getAuthToken() {
+  return storedAuthToken;
+}
+
 async function request(path, options = {}) {
   const url = `${API_BASE_URL}${path}`;
-  const config = {
-    headers: {
-      'Content-Type': 'application/json',
-      ...(options.headers || {}),
-    },
-    ...options,
+  const { authToken: explicitToken, headers: customHeaders = {}, ...restOptions } = options;
+  const token = explicitToken ?? storedAuthToken ?? null;
+  const headers = {
+    'Content-Type': 'application/json',
+    ...customHeaders,
   };
 
-  if (config.body && typeof config.body === 'object' && !(config.body instanceof FormData)) {
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const config = {
+    ...restOptions,
+    headers,
+  };
+
+  if (config.body instanceof FormData) {
+    delete config.headers['Content-Type'];
+  } else if (
+    config.body &&
+    typeof config.body === 'object' &&
+    !(config.body instanceof FormData)
+  ) {
     config.body = JSON.stringify(config.body);
   }
 
@@ -44,29 +70,33 @@ export async function loginCreator({ email, password }) {
   });
 }
 
-export async function createEvent(eventData) {
+export async function createEvent(eventData, token) {
   return request('/events', {
     method: 'POST',
     body: eventData,
+    authToken: token,
   });
 }
 
-export async function fetchNotifications(eventId) {
+export async function fetchNotifications(eventId, token) {
   return request(`/events/${eventId}/notifications`, {
     method: 'GET',
+    authToken: token,
   });
 }
 
-export async function acknowledgeNotification(eventId, notificationId) {
+export async function acknowledgeNotification(eventId, notificationId, token) {
   return request(`/events/${eventId}/notifications/${notificationId}`, {
     method: 'PATCH',
     body: { status: 'read' },
+    authToken: token,
   });
 }
 
-export async function resendNotification(eventId, participantEmail) {
+export async function resendNotification(eventId, participantEmail, token) {
   return request(`/events/${eventId}/notifications/resend`, {
     method: 'POST',
     body: { participantEmail },
+    authToken: token,
   });
 }


### PR DESCRIPTION
## Summary
- persist the authentication token separately from the user profile and expose it to the wizard
- extend the API client to manage bearer tokens and forward them with authenticated requests
- update the auth flow to hand back token/user and ensure event creation uses the token

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68caa22d1bf08320ba35865ac310bad6