### PR TITLE
Toggle snow animation for dark theme

### DIFF
--- a/web/packages/bootstrap/dist/css/bootstrap.min.css
+++ b/web/packages/bootstrap/dist/css/bootstrap.min.css
@@ -653,27 +653,6 @@ ol {
   right: -20px;
 }
 
-.holiday-illustration .snow {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.85) 1px, transparent 0),
-    radial-gradient(rgba(255, 255, 255, 0.6) 2px, transparent 0),
-    radial-gradient(rgba(255, 255, 255, 0.4) 1px, transparent 0);
-  background-size: 80px 80px, 110px 110px, 140px 140px;
-  animation: snowFall 18s linear infinite;
-  opacity: 0.6;
-}
-
-@keyframes snowFall {
-  0% {
-    background-position: 0 0, 0 0, 0 0;
-  }
-  100% {
-    background-position: 0 200px, 50px 220px, -40px 240px;
-  }
-}
-
 .app-shell {
   background: var(--bs-body-bg);
   color: var(--bs-body-color);

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -1,5 +1,37 @@
 @import 'bootstrap/dist/css/bootstrap.min.css';
 
+.holiday-illustration {
+  position: relative;
+}
+
+.holiday-illustration .snow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.85) 1px, transparent 0),
+    radial-gradient(rgba(255, 255, 255, 0.6) 2px, transparent 0),
+    radial-gradient(rgba(255, 255, 255, 0.4) 1px, transparent 0);
+  background-size: 80px 80px, 110px 110px, 140px 140px;
+  opacity: 0.6;
+  display: none;
+  animation: none;
+}
+
+@keyframes snowFall {
+  0% {
+    background-position: 0 0, 0 0, 0 0;
+  }
+
+  100% {
+    background-position: 0 200px, 50px 220px, -40px 240px;
+  }
+}
+
+[data-theme='dark'] .holiday-illustration .snow {
+  display: block;
+  animation: snowFall 18s linear infinite;
+}
+
 .holiday-script {
   font-family: var(--bs-font-heading);
   display: inline-block;


### PR DESCRIPTION
## Summary
- disable the default snow overlay so it stays hidden when the site loads in light mode
- recreate the snow effect and keyframes inside the SCSS bundle and enable it only when `data-theme="dark"`
- remove the vendor snow animation so light mode never animates by default

## Testing
- npm run build *(fails: local stub Sass implementation cannot resolve the Bootstrap import and CRA blocks the build)*

------
https://chatgpt.com/codex/tasks/task_e_68caa7dd02ec832081257f4b4ec3ff20