### PR TITLE
Add support for participant exclusion pairs in Secret Santa draw

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -265,6 +265,21 @@ async function initializeDatabase() {
       CONSTRAINT fk_participants_recipient FOREIGN KEY (assigned_recipient_id) REFERENCES participants(id) ON DELETE SET NULL
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
   );
+
+  await executeSql(
+    `CREATE TABLE IF NOT EXISTS participant_exclusions (
+      id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+      event_id INT UNSIGNED NOT NULL,
+      participant_a_id INT UNSIGNED NOT NULL,
+      participant_b_id INT UNSIGNED NOT NULL,
+      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (id),
+      UNIQUE KEY unique_participant_pair (event_id, participant_a_id, participant_b_id),
+      CONSTRAINT fk_exclusions_event FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+      CONSTRAINT fk_exclusions_participant_a FOREIGN KEY (participant_a_id) REFERENCES participants(id) ON DELETE CASCADE,
+      CONSTRAINT fk_exclusions_participant_b FOREIGN KEY (participant_b_id) REFERENCES participants(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+  );
 }
 
 // ---- Email sending -------------------------------------------------------
@@ -555,6 +570,119 @@ function validateParticipants(participants) {
   return { valid: true, participants: normalized };
 }
 
+function validateParticipantExclusions(participants, exclusions) {
+  if (!exclusions || exclusions.length === 0) {
+    return { valid: true, exclusions: [] };
+  }
+
+  if (!Array.isArray(exclusions)) {
+    return {
+      valid: false,
+      error: 'Format de couples invalide.',
+      fieldErrors: { exclusions: 'Format de couples invalide.' },
+    };
+  }
+
+  const participantEmails = new Set(participants.map((participant) => participant.email));
+  const normalized = [];
+  const seenPairs = new Set();
+
+  for (const pair of exclusions) {
+    if (!pair || typeof pair !== 'object') {
+      return {
+        valid: false,
+        error: 'Chaque couple doit référencer deux participants.',
+        fieldErrors: {
+          exclusions: 'Chaque couple doit référencer deux participants.',
+        },
+      };
+    }
+
+    const first = sanitizeEmail(
+      pair.participantA || pair.first || pair.a || pair.emailA || pair[0]
+    );
+    const second = sanitizeEmail(
+      pair.participantB || pair.second || pair.b || pair.emailB || pair[1]
+    );
+
+    if (!first || !second) {
+      return {
+        valid: false,
+        error: 'Sélectionnez deux participants pour former un couple.',
+        fieldErrors: {
+          exclusions: 'Sélectionnez deux participants pour former un couple.',
+        },
+      };
+    }
+
+    if (first === second) {
+      return {
+        valid: false,
+        error: 'Un participant ne peut pas être jumelé avec lui-même.',
+        fieldErrors: {
+          exclusions: 'Un participant ne peut pas être jumelé avec lui-même.',
+        },
+      };
+    }
+
+    if (!participantEmails.has(first) || !participantEmails.has(second)) {
+      return {
+        valid: false,
+        error: 'Les couples doivent correspondre à des participants existants.',
+        fieldErrors: {
+          exclusions: 'Les couples doivent correspondre à des participants existants.',
+        },
+      };
+    }
+
+    const pairKey = [first, second].sort().join('::');
+    if (seenPairs.has(pairKey)) {
+      return {
+        valid: false,
+        error: 'Ce couple est déjà défini.',
+        fieldErrors: { exclusions: 'Ce couple est déjà défini.' },
+      };
+    }
+
+    seenPairs.add(pairKey);
+    normalized.push({ participantA: first, participantB: second });
+  }
+
+  return { valid: true, exclusions: normalized };
+}
+
+async function replaceParticipantExclusions(eventId, participants, exclusions) {
+  await executeSql('DELETE FROM participant_exclusions WHERE event_id = ?', [eventId]);
+
+  if (!exclusions || exclusions.length === 0) {
+    return [];
+  }
+
+  const participantsByEmail = new Map(
+    participants.map((participant) => [sanitizeEmail(participant.email), participant.id])
+  );
+  const createdAt = nowDateTime();
+  const storedPairs = [];
+
+  for (const pair of exclusions) {
+    const firstId = participantsByEmail.get(pair.participantA);
+    const secondId = participantsByEmail.get(pair.participantB);
+    if (!firstId || !secondId || firstId === secondId) {
+      continue;
+    }
+    const [participantAId, participantBId] =
+      firstId < secondId ? [firstId, secondId] : [secondId, firstId];
+    await executeSql(
+      `INSERT INTO participant_exclusions (event_id, participant_a_id, participant_b_id, created_at)
+       VALUES (?, ?, ?, ?)`,
+      [eventId, participantAId, participantBId, createdAt]
+    );
+    storedPairs.push({ participantAId, participantBId });
+  }
+
+  return storedPairs;
+}
+
 async function createEvent(req, res) {
   const name = String(req.body.name || '').trim();
   const description = String(req.body.description || '').trim() || null;
@@ -572,6 +700,10 @@ async function createEvent(req, res) {
     eventDate = formatDateTime(parsedDate);
   }
   const validation = validateParticipants(req.body.participants);
+  const exclusionsValidation = validateParticipantExclusions(
+    validation.valid ? validation.participants : [],
+    req.body.exclusions
+  );
 
   if (!name) {
     return sendBadRequest(res, "Le nom de l'évènement est obligatoire", {
@@ -605,6 +737,15 @@ async function createEvent(req, res) {
     });
   }
 
+  if (!exclusionsValidation.valid) {
+    return sendBadRequest(res, exclusionsValidation.error, {
+      fieldErrors: exclusionsValidation.fieldErrors || {
+        exclusions: exclusionsValidation.error,
+      },
+      step: 'participants',
+    });
+  }
+
   const createdAt = nowDateTime();
   const eventInsert = await executeSql(
     `INSERT INTO events (owner_id, name, description, event_date, budget, location, created_at)
@@ -621,6 +762,22 @@ async function createEvent(req, res) {
     );
   }
 
+  const storedParticipants = (
+    await querySql(
+      `SELECT id, name, email, email_status as emailStatus, email_error as emailError,
+              email_sent_at as emailSentAt, created_at as createdAt,
+              assigned_recipient_id as assignedRecipientId
+       FROM participants WHERE event_id = ?`,
+      [eventId]
+    )
+  ).map(normalizeParticipantRow);
+
+  await replaceParticipantExclusions(
+    eventId,
+    storedParticipants,
+    exclusionsValidation.exclusions
+  );
+
   respondJson(res, 201, {
     event: {
       id: eventId,
@@ -631,6 +788,7 @@ async function createEvent(req, res) {
       location,
       createdAt: toIsoString(createdAt),
       participants: validation.participants,
+      exclusions: exclusionsValidation.exclusions,
     },
   });
 }
@@ -727,12 +885,29 @@ async function replaceEventParticipants(req, res) {
     ? req.body.participants
     : [];
   const validation = validateParticipants(participantsInput);
+  const exclusionsValidation = validateParticipantExclusions(
+    validation.valid ? validation.participants : [],
+    req.body.exclusions
+  );
 
   if (!validation.valid) {
     return sendBadRequest(res, validation.error || 'Participants invalides', {
       fieldErrors: validation.fieldErrors || { participants: validation.error },
       step: 'participants',
     });
+  }
+
+  if (!exclusionsValidation.valid) {
+    return sendBadRequest(
+      res,
+      exclusionsValidation.error || 'Couples invalides',
+      {
+        fieldErrors: exclusionsValidation.fieldErrors || {
+          exclusions: exclusionsValidation.error,
+        },
+        step: 'participants',
+      }
+    );
   }
 
   await executeSql('DELETE FROM participants WHERE event_id = ?', [eventId]);
@@ -748,8 +923,25 @@ async function replaceEventParticipants(req, res) {
 
   await executeSql('UPDATE events SET draw_generated = 0 WHERE id = ?', [eventId]);
 
+  const storedParticipants = (
+    await querySql(
+      `SELECT id, name, email, email_status as emailStatus, email_error as emailError,
+              email_sent_at as emailSentAt, created_at as createdAt,
+              assigned_recipient_id as assignedRecipientId
+       FROM participants WHERE event_id = ?`,
+      [eventId]
+    )
+  ).map(normalizeParticipantRow);
+
+  await replaceParticipantExclusions(
+    eventId,
+    storedParticipants,
+    exclusionsValidation.exclusions
+  );
+
   respondJson(res, 200, {
     participants: validation.participants,
+    exclusions: exclusionsValidation.exclusions,
   });
 }
 
@@ -762,14 +954,77 @@ function shuffleArray(array) {
   return arr;
 }
 
-function buildAssignments(participants) {
-  const shuffled = shuffleArray(participants);
-  const assignments = [];
-  for (let i = 0; i < shuffled.length; i += 1) {
-    const giver = shuffled[i];
-    const receiver = shuffled[(i + 1) % shuffled.length];
-    assignments.push({ giver, receiver });
+function buildAssignments(participants, exclusionPairs = []) {
+  const participantList = shuffleArray(participants);
+  const blockedRecipients = new Map();
+
+  for (const participant of participantList) {
+    blockedRecipients.set(participant.id, new Set([participant.id]));
   }
+
+  for (const pair of exclusionPairs || []) {
+    const giverId = Number(
+      pair.giverId ?? pair.participantAId ?? pair.participantId ?? pair[0]
+    );
+    const receiverId = Number(
+      pair.receiverId ?? pair.participantBId ?? pair.excludedParticipantId ?? pair[1]
+    );
+    if (!giverId || !receiverId) {
+      continue;
+    }
+    if (!blockedRecipients.has(giverId)) {
+      blockedRecipients.set(giverId, new Set([giverId]));
+    }
+    blockedRecipients.get(giverId).add(receiverId);
+  }
+
+  const allowedRecipients = new Map();
+  for (const participant of participantList) {
+    const blocked = blockedRecipients.get(participant.id) || new Set([participant.id]);
+    const allowed = shuffleArray(
+      participants.filter((candidate) => !blocked.has(candidate.id))
+    );
+    if (allowed.length === 0) {
+      throw new Error(
+        'Impossible de générer un tirage respectant les couples exclus.'
+      );
+    }
+    allowedRecipients.set(participant.id, allowed);
+  }
+
+  const assignments = [];
+  const usedReceivers = new Set();
+
+  function backtrack(index) {
+    if (index >= participantList.length) {
+      return true;
+    }
+
+    const giver = participantList[index];
+    const candidates = allowedRecipients.get(giver.id) || [];
+
+    for (const candidate of candidates) {
+      if (usedReceivers.has(candidate.id)) {
+        continue;
+      }
+      assignments.push({ giver, receiver: candidate });
+      usedReceivers.add(candidate.id);
+      if (backtrack(index + 1)) {
+        return true;
+      }
+      assignments.pop();
+      usedReceivers.delete(candidate.id);
+    }
+
+    return false;
+  }
+
+  if (!backtrack(0)) {
+    throw new Error(
+      'Impossible de générer un tirage respectant les couples exclus.'
+    );
+  }
+
   return assignments;
 }
 
@@ -800,7 +1055,31 @@ async function triggerDraw(req, res) {
     return sendBadRequest(res, 'Ajoutez au moins deux participants avant de lancer le tirage');
   }
 
-  const assignments = buildAssignments(participants);
+  const exclusionRows = await querySql(
+    `SELECT participant_a_id as participantAId, participant_b_id as participantBId
+     FROM participant_exclusions WHERE event_id = ?`,
+    [eventId]
+  );
+  const exclusionPairs = [];
+  for (const row of exclusionRows) {
+    if (!row.participantAId || !row.participantBId) {
+      continue;
+    }
+    exclusionPairs.push({ giverId: row.participantAId, receiverId: row.participantBId });
+    exclusionPairs.push({ giverId: row.participantBId, receiverId: row.participantAId });
+  }
+
+  let assignments;
+  try {
+    assignments = buildAssignments(participants, exclusionPairs);
+  } catch (error) {
+    return sendBadRequest(
+      res,
+      error instanceof Error
+        ? error.message
+        : 'Impossible de générer un tirage respectant les couples exclus.'
+    );
+  }
   const now = nowDateTime();
   const summary = [];
 

--- a/web/src/pages/EventWizard/ConfirmationStep.js
+++ b/web/src/pages/EventWizard/ConfirmationStep.js
@@ -1,11 +1,20 @@
 function ConfirmationStep({
   details,
   participants,
+  exclusions = [],
   onBack = () => {},
   onConfirm = () => {},
   loading,
   error,
 }) {
+  const resolveParticipantLabel = (email) => {
+    const participant = participants.find((item) => item.email === email);
+    if (!participant) {
+      return email;
+    }
+    return `${participant.name} — ${participant.email}`;
+  };
+
   return (
     <div className="confirmation-step d-flex flex-column gap-4">
       <header>
@@ -43,6 +52,25 @@ function ConfirmationStep({
           ))}
         </ul>
       </section>
+      {exclusions.length > 0 && (
+        <section>
+          <h3 className="fs-5 mb-3">Couples exclus</h3>
+          <ul className="list-group">
+            {exclusions.map((pair) => {
+              const key = [pair.participantA, pair.participantB]
+                .map((email) => email || '')
+                .sort()
+                .join('::');
+              return (
+                <li className="list-group-item" key={key}>
+                  {resolveParticipantLabel(pair.participantA)} ⇄{' '}
+                  {resolveParticipantLabel(pair.participantB)}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
       {error && (
         <div className="alert" role="alert">
           {error}

--- a/web/src/pages/EventWizard/EventWizard.js
+++ b/web/src/pages/EventWizard/EventWizard.js
@@ -36,6 +36,7 @@ function EventWizard({
   const [currentStep, setCurrentStep] = useState(0);
   const [details, setDetails] = useState(initialDetails);
   const [participants, setParticipants] = useState([]);
+  const [participantExclusions, setParticipantExclusions] = useState([]);
   const [submission, setSubmission] = useState({
     loading: false,
     error: '',
@@ -70,6 +71,7 @@ function EventWizard({
         budget: normalizedBudget,
         location: String(details.location || '').trim() || null,
         participants,
+        exclusions: participantExclusions,
         creatorId: creator?.id || null,
         creatorEmail: creator?.email || null,
       };
@@ -78,6 +80,11 @@ function EventWizard({
       const summaryParticipants = Array.isArray(eventData.participants)
         ? eventData.participants
         : participants;
+      const summaryExclusions = Array.isArray(eventData.exclusions)
+        ? eventData.exclusions
+        : Array.isArray(participantExclusions)
+        ? participantExclusions
+        : [];
       setSubmission({ loading: false, error: '' });
       setServerValidationErrors(createEmptyServerErrors());
       if (onComplete) {
@@ -87,6 +94,7 @@ function EventWizard({
           budget: eventData.budget ?? normalizedBudget,
           location: eventData.location ?? details.location,
           participants: summaryParticipants,
+          exclusions: summaryExclusions,
           creatorId: requestPayload.creatorId,
           creatorEmail: requestPayload.creatorEmail,
           name: eventData.name ?? requestPayload.name,
@@ -154,7 +162,18 @@ function EventWizard({
       stepContent = (
         <ParticipantsStep
           participants={participants}
-          onUpdate={setParticipants}
+          exclusions={participantExclusions}
+          onUpdate={(nextParticipants) => {
+            setParticipants(nextParticipants);
+            setParticipantExclusions((prev) =>
+              prev.filter(
+                (pair) =>
+                  nextParticipants.some((item) => item.email === pair.participantA) &&
+                  nextParticipants.some((item) => item.email === pair.participantB)
+              )
+            );
+          }}
+          onExclusionsChange={setParticipantExclusions}
           onNext={() => {
             setServerValidationErrors((prev) => ({
               ...prev,
@@ -174,6 +193,7 @@ function EventWizard({
         <ConfirmationStep
           details={details}
           participants={participants}
+          exclusions={participantExclusions}
           onBack={goBack}
           onConfirm={handleConfirm}
           loading={submission.loading}

--- a/web/src/pages/EventWizard/ParticipantsStep.js
+++ b/web/src/pages/EventWizard/ParticipantsStep.js
@@ -4,7 +4,9 @@ const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function ParticipantsStep({
   participants,
+  exclusions = [],
   onUpdate,
+  onExclusionsChange = () => {},
   onNext = () => {},
   onBack = () => {},
   onCancel = () => {},
@@ -13,11 +15,36 @@ function ParticipantsStep({
   const [candidate, setCandidate] = useState({ name: '', email: '' });
   const [fieldErrors, setFieldErrors] = useState({});
   const [globalError, setGlobalError] = useState('');
+  const [pairCandidate, setPairCandidate] = useState({
+    participantA: '',
+    participantB: '',
+  });
+  const [exclusionError, setExclusionError] = useState('');
 
   useEffect(() => {
-    setFieldErrors(externalErrors.fieldErrors || {});
+    const nextFieldErrors = externalErrors.fieldErrors || {};
+    setFieldErrors(nextFieldErrors);
     setGlobalError(externalErrors.global || '');
+    setExclusionError(nextFieldErrors.exclusions || '');
   }, [externalErrors]);
+
+  useEffect(() => {
+    setPairCandidate((previous) => {
+      const hasFirst = participants.some(
+        (participant) => participant.email === previous.participantA
+      );
+      const hasSecond = participants.some(
+        (participant) => participant.email === previous.participantB
+      );
+      if (hasFirst && hasSecond) {
+        return previous;
+      }
+      return {
+        participantA: hasFirst ? previous.participantA : '',
+        participantB: hasSecond ? previous.participantB : '',
+      };
+    });
+  }, [participants]);
 
   const sortedParticipants = useMemo(
     () =>
@@ -32,6 +59,9 @@ function ParticipantsStep({
     setFieldErrors({});
   };
 
+  const getPairKey = (pair) =>
+    [pair.participantA, pair.participantB].map((email) => email || '').sort().join('::');
+
   const handleCandidateChange = (event) => {
     const { name, value } = event.target;
     setCandidate((prev) => ({ ...prev, [name]: value }));
@@ -43,6 +73,12 @@ function ParticipantsStep({
       delete nextErrors[name];
       return nextErrors;
     });
+  };
+
+  const handlePairCandidateChange = (event) => {
+    const { name, value } = event.target;
+    setPairCandidate((previous) => ({ ...previous, [name]: value }));
+    setExclusionError('');
   };
 
   const handleAddParticipant = (event) => {
@@ -75,8 +111,50 @@ function ParticipantsStep({
     resetCandidate();
   };
 
+  const handleAddExclusion = (event) => {
+    event.preventDefault();
+
+    const participantEmails = new Set(participants.map((item) => item.email));
+    const first = pairCandidate.participantA;
+    const second = pairCandidate.participantB;
+
+    if (!first || !second) {
+      setExclusionError('Sélectionnez deux participants à exclure.');
+      return;
+    }
+
+    if (first === second) {
+      setExclusionError('Un participant ne peut pas être jumelé avec lui-même.');
+      return;
+    }
+
+    if (!participantEmails.has(first) || !participantEmails.has(second)) {
+      setExclusionError('Choisissez deux participants valides.');
+      return;
+    }
+
+    const pairKey = getPairKey({ participantA: first, participantB: second });
+    const exists = exclusions.some((pair) => getPairKey(pair) === pairKey);
+    if (exists) {
+      setExclusionError('Ce couple est déjà défini.');
+      return;
+    }
+
+    onExclusionsChange([
+      ...exclusions,
+      { participantA: first, participantB: second },
+    ]);
+    setPairCandidate({ participantA: '', participantB: '' });
+    setExclusionError('');
+  };
+
   const handleRemoveParticipant = (email) => {
     onUpdate(participants.filter((participant) => participant.email !== email));
+  };
+
+  const handleRemoveExclusion = (pair) => {
+    const targetKey = getPairKey(pair);
+    onExclusionsChange(exclusions.filter((item) => getPairKey(item) !== targetKey));
   };
 
   const handleNext = () => {
@@ -85,6 +163,7 @@ function ParticipantsStep({
       return;
     }
     setGlobalError('');
+    setExclusionError('');
     onNext();
   };
 
@@ -153,6 +232,98 @@ function ParticipantsStep({
           </ul>
         )}
       </div>
+      <section className="ParticipantsStep-exclusions d-flex flex-column gap-3">
+        <div>
+          <h3 className="fs-5 mb-1">Couples à exclure du tirage</h3>
+          <p className="text-muted mb-0">
+            Sélectionnez deux participants qui ne doivent pas s’offrir de cadeaux
+            entre eux (par exemple les couples).
+          </p>
+        </div>
+        <form className="row g-3 align-items-end" onSubmit={handleAddExclusion}>
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="exclusion-participant-a">
+              Participant 1
+            </label>
+            <select
+              id="exclusion-participant-a"
+              name="participantA"
+              className="form-select"
+              value={pairCandidate.participantA}
+              onChange={handlePairCandidateChange}
+            >
+              <option value="">Sélectionnez un participant</option>
+              {sortedParticipants.map((participant) => (
+                <option key={`pair-a-${participant.email}`} value={participant.email}>
+                  {participant.name} — {participant.email}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="exclusion-participant-b">
+              Participant 2
+            </label>
+            <select
+              id="exclusion-participant-b"
+              name="participantB"
+              className="form-select"
+              value={pairCandidate.participantB}
+              onChange={handlePairCandidateChange}
+            >
+              <option value="">Sélectionnez un participant</option>
+              {sortedParticipants.map((participant) => (
+                <option key={`pair-b-${participant.email}`} value={participant.email}>
+                  {participant.name} — {participant.email}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-4">
+            <button type="submit" className="btn btn-secondary w-100" disabled={sortedParticipants.length < 2}>
+              Ajouter le couple
+            </button>
+          </div>
+        </form>
+        {exclusionError && <div className="form-error">{exclusionError}</div>}
+        <div>
+          {exclusions.length === 0 ? (
+            <p className="text-muted mb-0">Aucun couple exclu pour le moment.</p>
+          ) : (
+            <ul className="list-group">
+              {exclusions.map((pair) => {
+                const first = participants.find(
+                  (participant) => participant.email === pair.participantA
+                );
+                const second = participants.find(
+                  (participant) => participant.email === pair.participantB
+                );
+                const firstLabel = first
+                  ? `${first.name} — ${first.email}`
+                  : pair.participantA;
+                const secondLabel = second
+                  ? `${second.name} — ${second.email}`
+                  : pair.participantB;
+                const pairKey = getPairKey(pair);
+                return (
+                  <li className="list-group-item d-flex justify-content-between align-items-center" key={pairKey}>
+                    <span>
+                      {firstLabel} ⇄ {secondLabel}
+                    </span>
+                    <button
+                      type="button"
+                      className="btn btn-link"
+                      onClick={() => handleRemoveExclusion(pair)}
+                    >
+                      Retirer
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </section>
       {globalError && (
         <div className="alert" role="alert">
           {globalError}

--- a/web/src/pages/EventWizard/ParticipantsStep.test.js
+++ b/web/src/pages/EventWizard/ParticipantsStep.test.js
@@ -5,7 +5,9 @@ import ParticipantsStep from './ParticipantsStep';
 describe('ParticipantsStep', () => {
   const defaultProps = {
     participants: [],
+    exclusions: [],
     onUpdate: jest.fn(),
+    onExclusionsChange: jest.fn(),
     onNext: jest.fn(),
     onBack: jest.fn(),
     onCancel: jest.fn(),
@@ -31,5 +33,34 @@ describe('ParticipantsStep', () => {
 
     await user.type(emailInput, 'alice@example.com');
     expect(emailInput).not.toHaveClass('is-invalid');
+  });
+
+  it('permet d’ajouter un couple à exclure', async () => {
+    const user = userEvent.setup();
+    const onExclusionsChange = jest.fn();
+    render(
+      <ParticipantsStep
+        {...defaultProps}
+        participants={[
+          { name: 'Alice', email: 'alice@example.com' },
+          { name: 'Bob', email: 'bob@example.com' },
+        ]}
+        onExclusionsChange={onExclusionsChange}
+      />
+    );
+
+    await user.selectOptions(
+      screen.getByLabelText(/Participant 1/i),
+      'alice@example.com'
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/Participant 2/i),
+      'bob@example.com'
+    );
+    await user.click(screen.getByRole('button', { name: /Ajouter le couple/i }));
+
+    expect(onExclusionsChange).toHaveBeenCalledWith([
+      { participantA: 'alice@example.com', participantB: 'bob@example.com' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- persist participant exclusion pairs in the backend and enforce them during draw generation
- extend the event creation wizard to let organisers declare excluded couples and display them at confirmation
- cover the new UI workflow with an interaction test for adding a couple

## Testing
- npm test -- --runTestsByPath src/pages/EventWizard/ParticipantsStep.test.js *(fails: react-scripts not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f60253c5e88320b8f00676872ebad5